### PR TITLE
Add copy-readme action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: Lint and test Helm charts
+
 on:
   pull_request:
-    paths:
-      - "charts/**"
+    branches: ["*"]
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
-name: test
+name: Lint and test Helm charts
 on:
   pull_request:
     paths:
       - "charts/**"
 jobs:
-  lint-chart:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/copy-readme.yml
+++ b/.github/workflows/copy-readme.yml
@@ -1,0 +1,26 @@
+name: Copy README to gh-pages
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "README.md"
+jobs:
+  copy:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          cp -f README.md ${{ runner.temp }}/README.md
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - run: |
+          cp -f ${{ runner.temp }}/README.md .
+          git config user.name "FiberBot"
+          git config user.email "fiberbot@users.noreply.github.com"
+          git add README.md
+          git commit --signoff -m "copy README from main"
+          git push


### PR DESCRIPTION
Small rename of the `test` action and adding another that will copy over the README every time it's changed. This way if people navigate to fiberplane.github.io/helm-charts it is available for them there
